### PR TITLE
Better Typescript support and support for CallExpression in _get parameters

### DIFF
--- a/__testfixtures__/skipVariables.input.js
+++ b/__testfixtures__/skipVariables.input.js
@@ -9,3 +9,4 @@ const foo4 = gett(bar, someVar);
 const foo5 = get(bar, someVar);
 const foo6 = _.get(bar, someKey);
 const foo7 = _.get(that.foo, that.bar);
+const foo8 = get(foo, getPath(name));

--- a/__testfixtures__/skipVariables.output.js
+++ b/__testfixtures__/skipVariables.output.js
@@ -9,3 +9,4 @@ const foo4 = gett(bar, someVar);
 const foo5 = get(bar, someVar);
 const foo6 = _.get(bar, someKey);
 const foo7 = _.get(that.foo, that.bar);
+const foo8 = get(foo, getPath(name));

--- a/__testfixtures__/transform.input.js
+++ b/__testfixtures__/transform.input.js
@@ -19,3 +19,4 @@ const foo14 = _.get(that.foo, that.bar);
 const foo15 = get(foo, 'bar[0]["60"]');
 const foo16 = get(foo, "bar.data-thing");
 const foo17 = get(foo, "data-bar[0].baz.data-thing", value);
+const foo18 = get(foo, getPath(name));

--- a/__testfixtures__/transform.output.js
+++ b/__testfixtures__/transform.output.js
@@ -16,3 +16,4 @@ const foo14 = that.foo?.[that.bar];
 const foo15 = foo?.bar?.[0]?.[60];
 const foo16 = foo?.bar?.["data-thing"];
 const foo17 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;
+const foo18 = foo?.[getPath(name)];

--- a/__testfixtures__/typescript.input.ts
+++ b/__testfixtures__/typescript.input.ts
@@ -1,0 +1,22 @@
+import _ from "lodash";
+import { get } from "lodash";
+import gett from "lodash/get";
+
+const foo1  = _.get(bar, "a.b.c");
+const foo2  = get(bar, "a.b.c");
+const foo3  = gett(bar, "a.b.c");
+const foo4  = gett(bar, "a[2].c");
+const foo5  = gett(bar, ["a", foo5, "c"]);
+const foo6  = gett(bar, ["a", 321, "c"]);
+const foo7  = gett(bar, ["a", this.smthng, "c"]);
+const foo8  = gett(bar, ["a", foo5, "c"], 123);
+const foo9  = gett(bar, ["a", foo5, "c"], "what");
+const foo10 = gett(bar, ["a", foo5, "c"], barr);
+const foo11 = _.get(bar, `a.${foo5}`);
+const foo12 = _.get(bar, `a.${foo5}.smthng`);
+const foo13 = _.get(bar, someKey);
+const foo14 = _.get(that.foo, that.bar);
+const foo15 = get(foo, 'bar[0]["60"]');
+const foo16 = get(foo, "bar.data-thing");
+const foo17 = get(foo, "data-bar[0].baz.data-thing", value);
+

--- a/__testfixtures__/typescript.input.ts
+++ b/__testfixtures__/typescript.input.ts
@@ -19,4 +19,5 @@ const foo14 = _.get(that.foo, that.bar);
 const foo15 = get(foo, 'bar[0]["60"]');
 const foo16 = get(foo, "bar.data-thing");
 const foo17 = get(foo, "data-bar[0].baz.data-thing", value);
+const foo18 = get(foo, getPath(name));
 

--- a/__testfixtures__/typescript.output.ts
+++ b/__testfixtures__/typescript.output.ts
@@ -15,3 +15,4 @@ const foo14 = that.foo?.[that.bar];
 const foo15 = foo?.bar?.[0]?.[60];
 const foo16 = foo?.bar?.["data-thing"];
 const foo17 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;
+const foo18 = foo?.[getPath(name)];

--- a/__testfixtures__/typescript.output.ts
+++ b/__testfixtures__/typescript.output.ts
@@ -1,0 +1,17 @@
+const foo1  = bar?.a?.b?.c;
+const foo2  = bar?.a?.b?.c;
+const foo3  = bar?.a?.b?.c;
+const foo4  = bar?.a?.[2]?.c;
+const foo5  = bar?.a?.[foo5]?.c;
+const foo6  = bar?.a?.[321]?.c;
+const foo7  = bar?.a?.[this.smthng]?.c;
+const foo8  = bar?.a?.[foo5]?.c ?? 123;
+const foo9  = bar?.a?.[foo5]?.c ?? "what";
+const foo10 = bar?.a?.[foo5]?.c ?? barr;
+const foo11 = bar?.a?.[foo5];
+const foo12 = bar?.a?.[foo5]?.smthng;
+const foo13 = bar?.[someKey];
+const foo14 = that.foo?.[that.bar];
+const foo15 = foo?.bar?.[0]?.[60];
+const foo16 = foo?.bar?.["data-thing"];
+const foo17 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;

--- a/__tests__/transform-test.js
+++ b/__tests__/transform-test.js
@@ -24,6 +24,17 @@ describe("lodash get to optional chaining", () => {
         "skipVariables"
       );
     });
+
+    describe("typescript", () => {
+      defineTest(
+        __dirname,
+        "transform",
+        null,
+        "typescript",
+        { parser: 'ts' },
+        { parser: 'ts' },
+      );
+    });
   });
 
   describe("mangle nested object checks", () => {

--- a/transform.js
+++ b/transform.js
@@ -70,8 +70,8 @@ const generateOptionalChain = (node, j) => {
         j
       );
     case "Identifier":
-      return defaultOptionalChain(node, j);
     case "MemberExpression":
+    case "CallExpression":
       return defaultOptionalChain(node, j);
     default:
       throw new Error(`argument type not supported "${node.value.arguments[1].type}"`);
@@ -88,6 +88,7 @@ const skip = (node, options) => {
       return !!options.skipTemplateStrings;
     case "Identifier":
     case "MemberExpression":
+    case "CallExpression":
       return !!options.skipVariables;
     default:
       throw new Error(`argument type not supported "${node.value.arguments[1].type}"`);


### PR DESCRIPTION
Due to differences in types for typescript and js all _.get calls were not replaced because all imports weren't discovered. 

I added support for `StringLiteral` as long as `Literal` type and this fixed the issue. 


During converting my codebase I encountered error caused by CallExpression in _.get function parameter, this PR adds support for this kind of statements.


All relative tests are updated and new tests for typescript are created. 
