### PR TITLE
feat: handle namespace import

### DIFF
--- a/__testfixtures__/typescript.input.ts
+++ b/__testfixtures__/typescript.input.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import * as star from "lodash";
 import { get } from "lodash";
 import gett from "lodash/get";
 
@@ -20,4 +21,5 @@ const foo15 = get(foo, 'bar[0]["60"]');
 const foo16 = get(foo, "bar.data-thing");
 const foo17 = get(foo, "data-bar[0].baz.data-thing", value);
 const foo18 = get(foo, getPath(name));
+const foo19 = star.get(bar, "a.b.c");
 

--- a/__testfixtures__/typescript.output.ts
+++ b/__testfixtures__/typescript.output.ts
@@ -16,3 +16,4 @@ const foo15 = foo?.bar?.[0]?.[60];
 const foo16 = foo?.bar?.["data-thing"];
 const foo17 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;
 const foo18 = foo?.[getPath(name)];
+const foo19 = bar?.a?.b?.c;


### PR DESCRIPTION
Fixes #29.

Allow `import * as star from "lodash";` with any identifier.

Be aware that I have no idea what I'm doing, just beating the AST explorer until it did what I want.

I had to extract a local method here, it's too much to put in a loop or to extract a global method, sorry.