### PR TITLE
Add example for how to transform .tsx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ with typescript parser:
 $ optional-chaining-codemod ./**/*.ts --parser=ts
 ```
 
+with typescript+react parser:
+
+```bash
+$ optional-chaining-codemod ./**/*.tsx --parser=tsx
+```
+
 The CLI is the same as in [jscodeshift](https://github.com/facebook/jscodeshift)
 except you can omit the transform file.
 


### PR DESCRIPTION
```sh
npx optional-chaining-codemod flow-report/src/sidebar/flow.tsx --parser=ts
```

```
flow-report/src/sidebar/flow.tsx Transformation error (Unexpected token, expected "," (21:6))
SyntaxError: Unexpected token, expected "," (21:6)
    at Object._raise (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/parser/error.js:147:45)
    at Object.raiseWithData (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/parser/error.js:142:17)
    at Object.raise (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/parser/error.js:91:17)
    at Object.unexpected (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/parser/util.js:175:16)
    at Object.expect (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/parser/util.js:135:28)
    at Object.tsParseDelimitedListWorker (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/plugins/typescript/index.js:421:16)
    at Object.tsParseDelimitedList (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/plugins/typescript/index.js:376:14)
    at Object.tsParseBracketedList (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/plugins/typescript/index.js:448:27)
    at Object.tsParseTypeParameters (/Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/plugins/typescript/index.js:555:26)
    at /Users/cjamcl/.npm/_npx/31117/lib/node_modules/optional-chaining-codemod/node_modules/@babel/parser/src/plugins/typescript/index.js:2898:31
All done.
```

On a hunch, I guess `--parser=tsx` is what I needed. I suggest adding a line about that to the README.

It'd be nice if the tool would assume the parser needed based on the file extensions found. For a large codebase that has various types of files (js, ts, tsx), currently the tool must be run multiple times like this:

```sh
npx optional-chaining-codemod flow-report/**/*.js
npx optional-chaining-codemod flow-report/**/*.ts --parser=ts
npx optional-chaining-codemod flow-report/**/*.tsx --parser=tsx
```

Ideally, it would just be:
```sh
npx optional-chaining-codemod flow-report
```

I'm not familiar with jscodeshift, so perhaps this is more an issue with that tool's API. If so, disregard :)