### PR TITLE
Add `--ignore-pattern="**/node_modules/**"` to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ $ npm install -g optional-chaining-codemod
 ## Usage
 
 ```bash
-$ optional-chaining-codemod ./**/*.js
+$ optional-chaining-codemod ./**/*.js --ignore-pattern="**/node_modules/**"
 ```
 
 with flow parser:
 
 ```bash
-$ optional-chaining-codemod ./**/*.js --parser=flow
+$ optional-chaining-codemod ./**/*.js --ignore-pattern="**/node_modules/**" --parser=flow
 ```
 
 with typescript parser:
 
 ```bash
-$ optional-chaining-codemod ./**/*.ts --parser=ts
+$ optional-chaining-codemod ./**/*.ts --ignore-pattern="**/node_modules/**" --parser=ts
 ```
 
 The CLI is the same as in [jscodeshift](https://github.com/facebook/jscodeshift)
@@ -67,7 +67,7 @@ Alternatively, you can run the codemod using jscodeshift as follows:
 ```bash
 $ yarn global add jscodeshift
 $ yarn add optional-chaining-codemod
-$ jscodeshift -t node_modules/optional-chaining-codemod/transform.js ./**/*.js
+$ jscodeshift -t node_modules/optional-chaining-codemod/transform.js --ignore-pattern="**/node_modules/**" ./**/*.js
 ```
 
 ### flags


### PR DESCRIPTION
Especially important when globbing form the root directory of a project.

I first tried running `npx optional-chaining-codemod .` but noticed it was processing all the node_modules too, which was unexpected. My project uses `yarn link` so we have symlinks in there, which results in this fun infinite loop :)

```
Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse" which does not exist.
Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/.bin/acorn" which does not exist.
Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/.bin/JSONStream" which does not exist.Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse" which does not exist.
Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/.bin/acorn" which does not exist.
Skipping path "node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/lighthouse/node_modules/.bin/JSONStream" which does not exist.

...
```