### PR TITLE
Wrap nullish coalescing to parentheses when in BinaryExpression

### DIFF
--- a/__testfixtures__/transform.input.js
+++ b/__testfixtures__/transform.input.js
@@ -22,3 +22,4 @@ const foo17 = get(foo, "data-bar[0].baz.data-thing", value);
 const foo18 = get(foo, getPath(name));
 const foo19 = get(foo, ["data-bar", 0, "baz", "data-thing"], value);
 const foo20 = get(foo, 1 + 1);
+const foo21 = get(foo, "bar", "baz") === "blah";

--- a/__testfixtures__/transform.output.js
+++ b/__testfixtures__/transform.output.js
@@ -19,3 +19,4 @@ const foo17 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;
 const foo18 = foo?.[getPath(name)];
 const foo19 = foo?.["data-bar"]?.[0]?.baz?.["data-thing"] ?? value;
 const foo20 = foo?.[1 + 1];
+const foo21 = (foo?.bar ?? "baz") === "blah";

--- a/transform.js
+++ b/transform.js
@@ -118,10 +118,22 @@ const swapArguments = (node, options) => {
   return node;
 };
 
+const parenthesize = (node, replacement) => {
+  if (node.parentPath.value.type === "BinaryExpression") {
+    replacement.extra || (replacement.extra = {});
+    replacement.extra.parenthesized = true;
+  }
+
+  return replacement;
+};
+
 const replaceGetWithOptionalChain = (node, j, shouldSwapArgs) =>
-  node.value.arguments[2]
-    ? addWithNullishCoalescing(node, j)
-    : generateOptionalChain(shouldSwapArgs ? swapArguments(node) : node, j);
+  parenthesize(
+    node,
+    node.value.arguments[2]
+      ? addWithNullishCoalescing(node, j)
+      : generateOptionalChain(shouldSwapArgs ? swapArguments(node) : node, j)
+  );
 
 const mangleLodashGets = (
   ast,


### PR DESCRIPTION
Equality has higher precedence than nullish coalescing operator. Default value in get should be wrapped into parenthesis to avoid changing the semantics of the expressions.