### PR TITLE
Parenthesize fallback value when necessary

### DIFF
--- a/__testfixtures__/transform.input.js
+++ b/__testfixtures__/transform.input.js
@@ -29,3 +29,4 @@ const foo24 = get(foo, "bar", 0) > 0;
 const foo25 = get(foo, "bar", 0) + 0;
 const foo26 = get(foo, "bar", 0) ?? 0;
 const foo27 = await get(foo, "bar", Promise.resolve());
+const foo28 = get(foo, "bar", bar || "bar");

--- a/__testfixtures__/transform.output.js
+++ b/__testfixtures__/transform.output.js
@@ -26,3 +26,4 @@ const foo24 = (foo?.bar ?? 0) > 0;
 const foo25 = (foo?.bar ?? 0) + 0;
 const foo26 = (foo?.bar ?? 0) ?? 0;
 const foo27 = await (foo?.bar ?? Promise.resolve());
+const foo28 = foo?.bar ?? (bar || "bar");

--- a/transform.js
+++ b/transform.js
@@ -109,7 +109,7 @@ const addWithNullishCoalescing = (node, j) =>
   j.logicalExpression(
     "??",
     generateOptionalChain(node, j),
-    node.value.arguments[2]
+    parenthesizeRight(node.value.arguments[2])
   );
 
 const swapArguments = (node, options) => {
@@ -118,15 +118,15 @@ const swapArguments = (node, options) => {
   return node;
 };
 
-const parenthesize = (node, replacement) => {
-  if (
-    [
-      "AwaitExpression",
-      "BinaryExpression",
-      "LogicalExpression",
-      "MemberExpression"
-    ].includes(node.parentPath.value.type)
-  ) {
+const parenthesizedExpressions = [
+  "AwaitExpression",
+  "BinaryExpression",
+  "LogicalExpression",
+  "MemberExpression"
+];
+
+const parenthesizeExpression = (node, replacement) => {
+  if (parenthesizedExpressions.includes(node.parentPath.value.type)) {
     replacement.extra || (replacement.extra = {});
     replacement.extra.parenthesized = true;
   }
@@ -134,8 +134,17 @@ const parenthesize = (node, replacement) => {
   return replacement;
 };
 
+const parenthesizeRight = node => {
+  if (parenthesizedExpressions.includes(node.type)) {
+    node.extra || (node.extra = {});
+    node.extra.parenthesized = true;
+  }
+
+  return node;
+};
+
 const replaceGetWithOptionalChain = (node, j, shouldSwapArgs) =>
-  parenthesize(
+  parenthesizeExpression(
     node,
     node.value.arguments[2]
       ? addWithNullishCoalescing(node, j)


### PR DESCRIPTION
Use same rules as for parenthesizing expression to parenthesize the default value.